### PR TITLE
Add precompilation for FourierTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 ShiftedArrays = "1277b4bf-5013-50f5-be3d-901d8477a67a"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
-
 ChainRulesCore = "1, 1.0, 1.1"
 FFTW = "1.5"
 ImageTransformations = "0.9"
@@ -25,6 +25,7 @@ NFFT = "0.11, 0.12, 0.13"
 PaddedViews = "0.5"
 Reexport = "1"
 ShiftedArrays = "2"
+SnoopPrecompile = "1"
 Zygote = "0.6"
 julia = "1, 1.6, 1.7, 1.8"
 

--- a/src/FourierTools.jl
+++ b/src/FourierTools.jl
@@ -8,6 +8,10 @@ using LinearAlgebra
 using IndexFunArrays
 using ChainRulesCore
 using NDTools
+
+using SnoopPrecompile
+
+
 @reexport using NFFT
 FFTW.set_num_threads(4)
 
@@ -30,5 +34,8 @@ include("correlations.jl")
 include("damping.jl")
 include("czt.jl")
 include("fractional_fourier_transform.jl")
+
+
+include("precompilation.jl")
 
 end # module

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,0 +1,28 @@
+# doesn't save too much but a little
+@precompile_setup begin
+    img64 = abs.(randn(Float32, (4,4)))
+    img32 = abs.(randn(Float64, (4,4)))
+    imgCF64 = abs.(randn(ComplexF64, (4,4)))
+    imgCF32 = abs.(randn(ComplexF32, (4,4)))
+
+    function f(img)
+        resample(img, (5,5))
+        resample(img, (2,2))
+        shift(img, (2,2))
+        shift(img, (2,2))
+        ft(img)
+        ffts(img)
+        ift(img)
+        iffts(img)
+        rotate(img, 1.1)
+        conv(img, img)
+    end
+
+    @precompile_all_calls begin
+        f(img64)
+        f(img32)
+        f(imgCF64)
+        f(imgCF32)
+    end
+
+end


### PR DESCRIPTION
Some timings for adding [SnoopPrecompile](https://timholy.github.io/SnoopCompile.jl/stable/snoop_pc/)

There is certainly improvement in Time-to-first-X (TTFX) but `using FourierTools` slowed down :/


```julia
# THIS PR

julia> @time @eval begin
        using FourierTools; resample(randn((3,3)), (4,4));
       end
  1.837442 seconds (4.37 M allocations: 330.662 MiB, 5.73% gc time, 37.63% compilation time: 35% of which was recompilation)
4×4 Matrix{Float64}:
  2.50649    0.177745  -1.26525     1.06349
  0.356397  -0.684275  -2.04213    -1.00146
 -1.33411   -0.982222  -0.792645   -1.14453
  0.815986  -0.120202  -0.0157615   0.920427



julia> @time @eval begin
        using FourierTools
       end
  1.233218 seconds (3.56 M allocations: 291.111 MiB, 7.55% gc time, 7.26% compilation time: 36% of which was recompilation)




# master branch

julia> @time begin
        using FourierTools
       end
  0.813568 seconds (2.46 M allocations: 178.026 MiB, 3.53% gc time, 9.22% compilation time: 25% of which was recompilation)

julia> @time @eval begin
        using FourierTools; resample(randn((3,3)), (4,4));
       end
  2.399415 seconds (8.97 M allocations: 544.981 MiB, 12.13% gc time, 69.04% compilation time: 1% of which was recompilation)
4×4 Matrix{Float64}:
 -0.206244   1.54404   2.20982   0.459536
  0.4502     1.25477   1.59361   0.789031
 -0.259531  -1.75128  -0.430379  1.06137
 -0.915975  -1.46202   0.185834  0.731878
```