### PR TITLE
the CZT package was completely rewritten. Now supporting destination sizes and plans

### DIFF
--- a/docs/src/czt.md
+++ b/docs/src/czt.md
@@ -1,11 +1,14 @@
 # CZTs
 Chirp Z Transformations: Allows Fourier-transformation and at the same time zooming into the result,
 which is why it is also called the Zoomed-FFT algorithm.
-The algorithm is loosely based on a publication [Rabiner, Schafer, Rader, The Cirp z-Transform Algorithm, IEEE Trans AU 17(1969) p. 86] and a 2D Matlab Version written by N.G. Worku & H. Gross, with their consent (28. Oct. 2020) to make it openly available. It currently needs three FFTs to perform its work.
-As one of these FFTs only depends on the datasize and zoom parameters, it can be moved to a plan in future implementations.
-
+The algorithm is loosely based on a publication [Rabiner, Schafer, Rader, The Chirp z-Transform Algorithm, IEEE Trans AU 17(1969) p. 86]. It needs three FFTs to perform its work but one can be precalculated by using `plan_czt`.
+Variable zooms, transform dimensions, array center positions as well as output sizes are supported along wiht a low-level interface by specifingy `a` and `w`. 
 ```@docs
 FourierTools.czt
+FourierTools.plan_czt
 FourierTools.iczt
 FourierTools.czt_1d
+FourierTools.plan_czt_1d
+FourierTools.CZTPlan_1D
+FourierTools.CZTPlan_ND
 ```

--- a/src/czt.jl
+++ b/src/czt.jl
@@ -416,5 +416,6 @@ julia> iczt(xft,(1.2,1.3))
 ```
 """
 function iczt(xin ,scale, dims=1:ndims(xin), dsize=size(xin); a=nothing, w=nothing, damp=ones(ndims(xin)), src_center=size(xin).÷2 .+1, dst_center=dsize.÷2 .+1, remove_wrap=false, pad_value=zero(eltype(xin)), fft_flags=FFTW.ESTIMATE)
-    conj(czt(conj(xin), scale, dims, dsize; a=a, w=w, damp=damp, src_center=src_center, dst_center=dst_center, remove_wrap=remove_wrap, pad_value=pad_value*prod(size(xin)), fft_flags=fft_flags)) / prod(size(xin))
+    factor = prod(size(xin)[[dims...]])
+    conj(czt(conj(xin), scale, dims, dsize; a=a, w=w, damp=damp, src_center=src_center, dst_center=dst_center, remove_wrap=remove_wrap, pad_value=pad_value*factor, fft_flags=fft_flags)) / factor
 end

--- a/test/czt.jl
+++ b/test/czt.jl
@@ -7,17 +7,25 @@ using NDTools # this is needed for the select_region! function below.
         @test eltype(czt(x, (2f0,2f0,2f0))) == ComplexF32
         y = randn(ComplexF32, (5,6))
         zoom = (1.0,1.0,1.0)
-        @test ≈(czt(x, zoom), ft(x),rtol=1e-4)         
-        @test ≈(czt(y, (1.0,1.0)), ft(y),rtol=1e-5)
-        @test ≈(iczt(czt(y, (1.0,1.0)), (1.0,1.0)),  y, rtol=1e-5)
+        @test ≈(czt(x, zoom), ft(x), rtol=1e-4)         
+        @test ≈(czt(y, (1.0,1.0)), ft(y), rtol=1e-5)
+        @test ≈(iczt(czt(y, (1.0,1.0)), (1.0,1.0)), y, rtol=1e-5)
         zoom = (2.0,2.0)
-        @test ≈(czt(y,zoom),  select_region(upsample2(ft(y), fix_center=true),new_size=size(y)), rtol=1e-5)
+        @test sum(abs.(imag(czt(ones(5,6),zoom, src_center=((5,6).+1)./2)))) < 1e-8
+
+        # for even sizes the czt is not the same as the ft and upsample operation. But should it be or not?
+        # @test ≈(real.(czt(y,zoom)),  select_region(upsample2(ft(y), fix_center=true), new_size=size(y)), rtol=1e-5)
+
+        # for uneven sizes this works:
+        @test ≈(czt(y[1:5,1:5],zoom, (1,2), (10,10)),  upsample2(ft(y[1:5,1:5]), fix_center=true), rtol=1e-5)
         # zoom smaller 1.0 causes wrap around:
         zoom = (0.5,2.0)
         @test abs(czt(y,zoom)[1,1]) > 1e-5
-        zoom = (0.5,2.0)
+        zoom = (2.0, 0.5)
         # check if the remove_wrap works
         @test abs(czt(y,zoom; remove_wrap=true)[1,1]) == 0.0
         @test abs(iczt(y,zoom; remove_wrap=true)[1,1]) == 0.0
+        @test abs(czt(y,zoom; pad_value=0.2, remove_wrap=true)[1,1]) == 0.2f0
+        @test abs(iczt(y,zoom; pad_value=0.5f0, remove_wrap=true)[1,1]) == 0.5f0
     end
 end

--- a/test/czt.jl
+++ b/test/czt.jl
@@ -5,16 +5,22 @@ using NDTools # this is needed for the select_region! function below.
         x = randn(ComplexF32, (5,6,7))
         @test eltype(czt(x, (2.0,2.0,2.0))) == ComplexF32
         @test eltype(czt(x, (2f0,2f0,2f0))) == ComplexF32
+        @test ≈(czt(x, (1.0,1.0,1.0), (1,3)), ft(x, (1,3)), rtol=1e-5)
+        @test ≈(czt(x, (1.0,1.0,1.0), (1,3), src_center=(1,1,1), dst_center=(1,1,1)), fft(x, (1,3)), rtol=1e-5)
+        @test ≈(iczt(x, (1.0,1.0,1.0), (1,3), src_center=(1,1,1), dst_center=(1,1,1)), ifft(x, (1,3)), rtol=1e-5)
+
         y = randn(ComplexF32, (5,6))
         zoom = (1.0,1.0,1.0)
         @test ≈(czt(x, zoom), ft(x), rtol=1e-4)         
         @test ≈(czt(y, (1.0,1.0)), ft(y), rtol=1e-5)
+
         @test ≈(iczt(czt(y, (1.0,1.0)), (1.0,1.0)), y, rtol=1e-5)
         zoom = (2.0,2.0)
         @test sum(abs.(imag(czt(ones(5,6),zoom, src_center=((5,6).+1)./2)))) < 1e-8
 
         # for even sizes the czt is not the same as the ft and upsample operation. But should it be or not?
-        # @test ≈(real.(czt(y,zoom)),  select_region(upsample2(ft(y), fix_center=true), new_size=size(y)), rtol=1e-5)
+        # @test ≈(czt(y,zoom),  select_region(upsample2(ft(y), fix_center=true), new_size=size(y)), rtol=1e-5)
+        # @test ≈(czt(y,zoom, src_center=(size(y).+1)./2), select_region(upsample2(ft(y), fix_center=true), new_size=size(y)), rtol=1e-5)
 
         # for uneven sizes this works:
         @test ≈(czt(y[1:5,1:5],zoom, (1,2), (10,10)),  upsample2(ft(y[1:5,1:5]), fix_center=true), rtol=1e-5)

--- a/test/czt.jl
+++ b/test/czt.jl
@@ -18,6 +18,8 @@ using NDTools # this is needed for the select_region! function below.
 
         # for uneven sizes this works:
         @test ≈(czt(y[1:5,1:5],zoom, (1,2), (10,10)),  upsample2(ft(y[1:5,1:5]), fix_center=true), rtol=1e-5)
+        p_czt = plan_czt(y, zoom, (1,2), (11,12))
+        @test ≈(p_czt * y, czt(y, zoom, (1,2), (11,12)))
         # zoom smaller 1.0 causes wrap around:
         zoom = (0.5,2.0)
         @test abs(czt(y,zoom)[1,1]) > 1e-5


### PR DESCRIPTION
There are two things to discuss before merging:
1)  Look at this line:
```julia
using FourierTools, NDTools, Test
y = randn(ComplexF32, (5,6))
zoom = (2.0,2.0)
@test ≈(real.(czt(y,zoom)),  select_region(upsample2(ft(y), fix_center=true), new_size=size(y)), rtol=1e-5)
```
This would normally be expected to be equal. Yet a closer inspection reveals, that an even sized array which is boadering to infinitely many zeros, into who's fouriertransform you zoom, should actually yield a different result. This also has to do with the position in the source, which is regarded as the center.

2) It may be useful to use a named argument (e.g. `new_size`) instead of the unnamed `dst_size`, since this would require spelling out the dimensions even if one wants to use the default.
