### PR TITLE
Forcing the output to be the same type as input in `damp_edge_outside`

### DIFF
--- a/src/damping.jl
+++ b/src/damping.jl
@@ -56,7 +56,7 @@ function damp_edge_outside(img::AbstractArray{T, N}, border=0.1, mykernel=nothin
     nimg2 = real(ift(ft(nimg) .* transfer)); 
     wimg2 = real(ift(ft(wimg) .* transfer));
 
-    nimg = nimg2 ./ wimg2;
+    nimg = T.(nimg2 ./ wimg2);
     if usepixels > 0
         # replace the original in the middle
         NDTools.select_region!(img, nimg)  


### PR DESCRIPTION
There was a problem with the `eltype` of the arrays in the function `damp_edge_outside`.
By forcing the array element type, the result of this function has the same element type as the input array.


```julia-repl
julia> a = ones(Float32, (10, 10));

julia> eltype(a)
Float32

julia> b = damp_edge_outside(a, 0.4);

julia> eltype(b)
Float32
```