### PR TITLE
Corrected the bug with the result `eltype` of the `damp_edge_outside`

### DIFF
--- a/src/damping.jl
+++ b/src/damping.jl
@@ -30,7 +30,7 @@ function damp_edge_outside(img::AbstractArray{T, N}, border=0.1, mykernel=nothin
     rborder=ceil.(Int,border.*size(img));
     new_size=size(img).+ rborder;
     if isnothing(mykernel)
-        mykernel = (one(T)./rr(new_size)) .- one(T)./norm(rborder.*sqrt(2.0));
+        mykernel = (one(T)./rr(T, new_size)) .- one(T)./norm(rborder.*sqrt(T(2.0)));
         # clip at zero
         mykernel .= max.(mykernel, zero(T)); 
         mykernel=mykernel .^ kernelpower;


### PR DESCRIPTION
There was a problem with the `eltype` of the arrays in the function `damp_edge_outside`.
By forcing the array element type, the result of this function has the same element type as the input array.

```julia-repl
julia> a = ones(Float32, (10, 10));

julia> b = damp_edge_outside(a, 0.5);

julia> eltype(b)
Float32
```