### PR TITLE
Migrated to CUDA 6 (and CUDA 5) support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,13 +22,12 @@ CUDASupportExt_FT = ["CUDA", "Adapt"]
 
 [compat]
 Adapt = "3.7, 4.0, 4.1"
-CUDA = "5.2, 5.3, 5.4, 5.5, 5.6, 5.7"
+CUDA = "5, 6"
 ChainRulesCore = "1"
-Cthulhu = "2.16.6"
 FFTW = "1.5, 1.6, 1.7, 1.8, 1.9"
 ImageTransformations = "0.9, 0.10"
 IndexFunArrays = "0.2"
-MutableShiftedArrays = "0.2, 0.3"
+MutableShiftedArrays = "0.2, 0.3, 0.4"
 NDTools = "0.8"
 NFFT = "0.11, 0.12, 0.13, 0.14"
 Reexport = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ ChainRulesCore = "1"
 FFTW = "1.5, 1.6, 1.7, 1.8, 1.9"
 ImageTransformations = "0.9, 0.10"
 IndexFunArrays = "0.2"
-MutableShiftedArrays = "0.2, 0.3, 0.4"
+MutableShiftedArrays = "0.2, 0.3, 0.4.2"
 NDTools = "0.8"
 NFFT = "0.11, 0.12, 0.13, 0.14"
 Reexport = "1"
@@ -42,7 +42,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 
 [targets]
-test = ["Test", "TestImages", "FractionalTransforms", "Random", "ImageTransformations", "Zygote", "CUDA", "Cthulhu"]
+test = ["Test", "TestImages", "FractionalTransforms", "Random", "ImageTransformations", "Zygote", "CUDA"]

--- a/ext/CUDASupportExt_FT.jl
+++ b/ext/CUDASupportExt_FT.jl
@@ -27,14 +27,19 @@ const AllShiftedAndViewsCu{N, CD} = Union{AllShiftedTypeCu{N, CD}, AllSubArrayTy
 Adapt.adapt_structure(to, x::FourierTools.FourierSplit{T, M, AA, D}) where {T, M, AA, D} = FourierTools.FourierSplit(adapt(to, parent(x)), Val(D), x.L1, x.L2, x.do_split);
 Adapt.adapt_structure(to, x::FourierTools.FourierJoin{T, M, AA, D}) where {T, M, AA, D} = FourierTools.FourierJoin(adapt(to, parent(x)), Val(D), x.L1, x.L2, x.do_join);
 
+Adapt.parent_type(::Type{FourierTools.FourierSplit{_T, _M, AA, _D}}) where {_T,_M,AA,_D} = AA
+Adapt.parent_type(::Type{FourierTools.FourierJoin{_T, _M, AA, _D}}) where {_T,_M,AA,_D} = AA
+
+Adapt.unwrap_type(W::Type{<:FourierTools.FourierSplit}) = unwrap_type(parent_type(W))
+Adapt.unwrap_type(W::Type{<:FourierTools.FourierJoin}) = unwrap_type(parent_type(W))
+
 function Base.Broadcast.BroadcastStyle(::Type{T})  where {N, CD, T<:AllShiftedTypeCu{N, CD}}
-    CUDA.CuArrayStyle{N,CD}()
+    return Base.Broadcast.BroadcastStyle(unwrap_type(T))
 end
 
 # Define the BroadcastStyle for SubArray of MutableShiftedArray with CuArray
-
 function Base.Broadcast.BroadcastStyle(::Type{T})  where {N, CD, T<:AllSubArrayTypeCu{N, CD}}
-    CUDA.CuArrayStyle{N,CD}()
+    return Base.Broadcast.BroadcastStyle(unwrap_type(T))
 end
 
 function Base.copy(s::AllShiftedAndViews)

--- a/src/convolutions.jl
+++ b/src/convolutions.jl
@@ -144,45 +144,45 @@ function plan_conv(u::AbstractArray{T1, N}, v::AbstractArray{T2, M}, dims=ntuple
     return v_ft, conv
 end
 
-"""
-    plan_conv_buffer(u, v [, dims]; kwargs...)
+# """
+#     plan_conv_buffer(u, v [, dims]; kwargs...)
 
-Similar to [`plan_conv`](@ref) but instead uses buffers to prevent memory allocations.
-The three buffers are internal to the function and are not exposed to the user.
-Not AD friendly!
+# Similar to [`plan_conv`](@ref) but instead uses buffers to prevent memory allocations.
+# The three buffers are internal to the function and are not exposed to the user.
+# Not AD friendly!
 
-"""
-function plan_conv_buffer(u::AbstractArray{T1, N}, v::AbstractArray{T2, M}, dims=ntuple(+, N);
-                   kwargs...) where {T1, T2, N, M}
-    eltype_error(T1, T2)
-    plan = get_plan(T1)
-    # do the preplanning step
-    P_u = plan(u, dims; kwargs...)
-    P_v = plan(v, dims)
+# """
+# function plan_conv_buffer(u::AbstractArray{T1, N}, v::AbstractArray{T2, M}, dims=ntuple(+, N);
+#                    kwargs...) where {T1, T2, N, M}
+#     eltype_error(T1, T2)
+#     plan = get_plan(T1)
+#     # do the preplanning step
+#     P_u = plan(u, dims; kwargs...)
+#     P_v = plan(v, dims)
 
-    u_buff = P_u * u
-    v_ft = P_v * v
-    uv_sz = bc_size(u_buff, v_ft)
-    # this saves memory allocations:
-    uv_buff = (uv_sz == size(u_buff)) ? u_buff : u_buff .* v_ft;
+#     u_buff = P_u * u
+#     v_ft = P_v * v
+#     uv_sz = bc_size(u_buff, v_ft)
+#     # this saves memory allocations:
+#     uv_buff = (uv_sz == size(u_buff)) ? u_buff : u_buff .* v_ft;
     
-    # for fourier space we need a new plan
-    P = plan(u .* v, dims; kwargs...)
-    P_inv = inv(P)
-    out_buff = P_inv * uv_buff
+#     # for fourier space we need a new plan
+#     P = plan(u .* v, dims; kwargs...)
+#     P_inv = inv(P)
+#     out_buff = P_inv * uv_buff
 
-    # construct the efficient conv function
-    # P and P_inv can be understood like matrices
-    # but their computation is fast
-    function conv(u, v_ft=v_ft)
-        mul!(u_buff, P_u, u)
-        uv_buff .= u_buff .* v_ft
-        mul!(out_buff, P_inv, uv_buff)
-        return out_buff
-    end
+#     # construct the efficient conv function
+#     # P and P_inv can be understood like matrices
+#     # but their computation is fast
+#     function conv(u, v_ft=v_ft)
+#         mul!(u_buff, P_u, u)
+#         uv_buff .= u_buff .* v_ft
+#         mul!(out_buff, P_inv, uv_buff)
+#         return out_buff
+#     end
 
-    return v_ft, conv
-end
+#     return v_ft, conv
+# end
 
 """
     plan_conv_psf_buffer(u, psf [, dims]; kwargs...) where {T, N}
@@ -192,6 +192,122 @@ end
 function plan_conv_psf_buffer(u::AbstractArray{T, N}, psf::AbstractArray{T, M}, dims=ntuple(+, N);
                        kwargs...) where {T, N, M}
     return plan_conv_buffer(u, ifftshift(psf, dims), dims; kwargs...)
+end
+
+# Define the struct
+struct CallablePlan{IAT<:AbstractArray, CT1<:AbstractArray, CT2<:AbstractArray, CT3<:AbstractArray}
+    P_u
+    # This is only needed due to a bug in CUDA freeing the plan when wrapped it in "inv":
+    P_for_inv
+    P_inv
+    v_ft::CT1
+    u_buff::CT2 # dimensions can be different
+    uv_buff::CT3 # final dimension can be different again
+    out_buff::IAT # final datatype and size can also vary
+end
+
+# Define the call method for the struct
+function (c::CallablePlan{IAT, CT1, CT2, CT3})(u::AbstractArray, v_ft::CT1) where {IAT<:AbstractArray, CT1<:AbstractArray, CT2<:AbstractArray, CT3<:AbstractArray}
+    return p_conv_aux!(c.P_u, c.P_inv, u, v_ft, c.u_buff, c.uv_buff, c.out_buff)
+end
+
+function (c::CallablePlan{IAT, CT1, CT2, CT3})(u::AbstractArray) where {IAT<:AbstractArray, CT1<:AbstractArray, CT2<:AbstractArray, CT3<:AbstractArray}
+    return p_conv_aux!(c.P_u, c.P_inv, u, c.v_ft, c.u_buff, c.uv_buff, c.out_buff)
+end
+
+
+"""
+    plan_conv_buffer(u, v [, dims])
+
+Pre-plan an optimized convolution for arrays shaped like `u` and `v` (based on pre-plan FFT)
+along the given dimensions `dims`.
+`dims = 1:ndims(u)` per default.
+The 0 frequency of `u` must be located at the first entry.
+We return two arguments: 
+The first one is `v_ft` (obtained by `fft(v)` or `rfft(v)`).
+The second return is the convolution function `pconv`.
+`pconv` itself has two arguments. `pconv(u, v_ft=v_ft)` where `u` is the object and `v_ft` the v_ft.
+This function achieves faster convolution than `conv(u, u)`.
+Depending whether `u` is real or complex we do `fft`s or `rfft`s
+
+# Warning
+The resulting output of the `pconv` function is a reference to an internal, allocated array.
+If you use the `pconv` function for different tasks, 
+a new call to `pconv` will change the previous result (since the previous result was only a reference, not a new array). 
+
+
+# Examples
+```jldoctest
+julia> u = [1 2 3 4 5]
+1×5 Matrix{Int64}:
+ 1  2  3  4  5
+julia> v = [1 0 0 0 0]
+1×5 Matrix{Int64}:
+ 1  0  0  0  0
+julia> v_ft, pconv = plan_conv(u, v);
+julia> pconv(u, v_ft)
+1×5 Matrix{Float64}:
+ 1.0  2.0  3.0  4.0  5.0
+julia> pconv(u)
+1×5 Matrix{Float64}:
+ 1.0  2.0  3.0  4.0  5.0
+```
+"""
+function plan_conv_buffer(u::AbstractArray{T, N}, v::AbstractArray{T, M}, dims=ntuple(+, N)) where {T, N, M}
+    plan = get_plan(T)
+    # do the preplanning step
+    P = plan(u, dims)
+    # inpout FT storage
+    u_buff = P * u
+    # P_inv = inv(P)
+    # out = u .* v # similar(u)
+    out_buff = similar(u, Base.Broadcast.broadcast_shape(size(u),size(v)))
+    u = expand_dims(u, Val(max(N,M)))
+    v = expand_dims(v, Val(max(N,M)))
+
+    v_ft = fft_or_rfft(T)(v, dims)
+
+    uv_buff = similar(v_ft, Base.Broadcast.broadcast_shape(size(u_buff),size(v_ft)))
+    
+    P_for_inv = plan(out_buff, dims)
+    P_inv = inv(P_for_inv)
+
+    # construct the efficient conv function
+    # P and P_inv can be understood like matrices
+    # but their computation is fast
+    conv = CallablePlan(P, P_for_inv, P_inv, v_ft, u_buff, uv_buff, out_buff)
+    return v_ft, conv
+end
+
+# axiliary function to use with planned convolutions
+function p_conv_aux!(P, P_inv, u, v_ft, u_buff, uv_buff, out) # , P_for_inv
+    #return P_inv.scale .* (P_inv.p * ((P * u) .* v_ft))  
+    mul!(u_buff, P, u)
+    # may be in place or out-of-place:
+    uv_buff .= u_buff .* v_ft .* P_inv.scale
+    mul!(out, P_inv.p, uv_buff)
+    #out2 = out .* P_inv.scale
+   return out
+end
+
+function ChainRulesCore.rrule(::typeof(p_conv_aux!), P, P_inv, u, v, u_buff, uv_buff, out, P_for_inv)
+    Y = p_conv_aux!(P, P_inv, u, v, u_buff, uv_buff, out, P_for_inv)
+    function conv_pullback(barx)
+        conj_v = let
+            if eltype(v) <: Real
+                v
+            else
+                conj(v)
+            end
+        end
+        if eltype(barx) <: Real
+            barx2 = similar(u, promote_type(eltype(u), eltype(barx)))
+            barx2 .= barx
+        end
+        ∇ = p_conv_aux!(P, P_inv, barx2, conj_v, u_buff, uv_buff, copy(out))
+        return NoTangent(), NoTangent(), NoTangent(), ∇, NoTangent(), NoTangent(), NoTangent(), NoTangent()
+    end 
+    return Y, conv_pullback
 end
 
 

--- a/test/convolutions.jl
+++ b/test/convolutions.jl
@@ -49,26 +49,32 @@
     conv_test(psf, img, img_out, dims, "Convolution with random 3D PSF and random 3D image over 2D dimensions")
 
     # Cuda has problems with >3D FFTs
-    if (!use_cuda)
-        N = 5
-        psf = opt_cu(abs.(randn((N, N, N, N, N))), use_cuda)
-        img = opt_cu(randn((N, N, N, N, N)), use_cuda)
-        dims = [1, 2, 3, 4]
-        img_out = conv_gen(img, psf, dims)
-        conv_test(psf, img, img_out, dims, "Convolution with random 5D PSF and random 5D image over 4 Dimensions")
 
-        N = 5
-        psf = abs.(zeros((N, N, N, N, N)))
+    dims = [1, 2, 3, 4]
+    if (use_cuda)
+        dims = [1,2,5] # cuda can handle at max 3 transform directions, old CUDA 5 could only handle specific combinations
+    end
+    N = 5
+    psf = opt_cu(abs.(randn((N, N, N, N, N))), use_cuda)
+    img = opt_cu(randn((N, N, N, N, N)), use_cuda)
+    img_out = conv_gen(img, psf, dims)
+    conv_test(psf, img, img_out, dims, "Convolution with random 5D PSF and random 5D image over 4 Dimensions")
+
+    N = 5
+    psf = abs.(zeros((N, N, N, N, N)))
+    if (use_cuda)
+        for i = 1:N, j = 1:N
+            psf[1,1,i,j, 1] = 1 # since CUDA can only convolve over maximally 3 dims in total
+        end
+    else
         for i = 1:N
             psf[1,1,1,1, i] = 1
         end
-        opt_cu(psf, use_cuda)
-        img = opt_cu(randn((N, N, N, N, N)), use_cuda)
-        dims = [1, 2, 3, 4]
-        img_out = conv_gen(img, psf, dims)
-        conv_test(psf, img, img, dims, "Convolution with 5D delta peak and random 5D image over 4 Dimensions")
     end
-
+    psf = opt_cu(psf, use_cuda)
+    img = opt_cu(randn((N, N, N, N, N)), use_cuda)
+    img_out = conv_gen(img, psf, dims)
+    conv_test(psf, img, img, dims, "Convolution with 5D delta peak and random 5D image over 4 Dimensions");
 
     @testset "Check broadcasting convolution" begin
         img = opt_cu(randn((5,6,7)), use_cuda)
@@ -104,15 +110,13 @@
         @test conv(img, psf) ≈ conv(img, psf, dims)
     end
 
-    if (!use_cuda)
-        @testset "adjoint convolution" begin
-            x = opt_cu(randn(ComplexF32, (5,6)), use_cuda)
-            y = opt_cu( randn(ComplexF32, (5,6)), use_cuda)
+    @testset "adjoint convolution" begin
+        x = opt_cu(randn(ComplexF32, (5,6)), use_cuda)
+        y = opt_cu(randn(ComplexF32, (5,6)), use_cuda)
 
-            y_ft, p = plan_conv(x, y)
-            @test ≈(exp(1im * 1.23) .+ conv(ones(eltype(y), size(x)), conj.(y)), exp(1im * 1.23) .+ Zygote.gradient(x -> sum(real(conv(x, y))), x)[1], rtol=1e-4)   
-            @test ≈(exp(1im * 1.23) .+ conv(ones(ComplexF32, size(x)), conj.(y)), exp(1im * 1.23) .+ Zygote.gradient(x -> sum(real(p(x, y_ft))), x)[1], rtol=1e-4) 
-        end
+        y_ft, p = plan_conv(x, y)
+        @test ≈(exp(1im * 1.23) .+ conv(opt_cu(ones(eltype(y), size(x)), use_cuda), conj.(y)), exp(1im * 1.23) .+ Zygote.gradient(x -> sum(real(conv(x, y))), x)[1], rtol=1e-4)   
+        @test ≈(exp(1im * 1.23) .+ conv(opt_cu(ones(ComplexF32, size(x)), use_cuda), conj.(y)), exp(1im * 1.23) .+ Zygote.gradient(x -> sum(real(p(x, y_ft))), x)[1], rtol=1e-4) 
     end
 
 end

--- a/test/resampling_tests.jl
+++ b/test/resampling_tests.jl
@@ -4,7 +4,7 @@
             for _ in 1:5
                 s_small = ntuple(_ -> rand(1:13), dim)
                 s_large = ntuple(i -> max.(s_small[i], rand(10:16)), dim)
-                                
+
                 x = opt_cu(randn(Float32, (s_small)), use_cuda)
                 @test x == resample(x, s_small)
                 @test Float32.(x) ≈ Float32.(resample(resample(x, s_large), s_small))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ function run_all_tests()
     include("fourier_shear.jl");
     include("fourier_rotate.jl");
     include("resampling_tests.jl"); ### nfft does not work with CUDA -> warning for this method
-    include("convolutions.jl"); # spurious buffer problem in conv_p4 in CUDA?
+    include("convolutions.jl"); 
     include("correlations.jl");
     include("custom_fourier_types.jl"); 
     include("damping.jl");


### PR DESCRIPTION
This Version should run under both CUDA versions.
I tested in CUDA 5.9 and CUDA 6.1 and both tests were passed.

One slightly more major change is the `plan_conv_buffer` function, which is now based on a callable structure.
It also circumvents a strange bug in the plan memory management in CUDA, where plans are freed to early under some conditions. 

This version now also supports a wider range of transform directions under CUDA 6 and it should also be faster with CZTs and single Y-dimension FTs in CUDA.

A quick release of a new version is appreciated. I already bumped the minor version number,but this may also be a major version update.